### PR TITLE
Add setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+from setuptools import find_packages, setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+
+setup(
+    name="osd",
+    version="0.0.1",
+    description="Optimzation-based signal decomposition",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    setup_requires=["setuptools>=18.0"],
+    install_requires=[
+        "cvxpy",
+        "matplotlib", 
+        "numpy",
+        "pandas",
+        "scipy",
+        "sklearn",
+    ],
+    packages=find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
+)


### PR DESCRIPTION
Removes the need to append to sys.path, which is error-prone.

Instead, you can just type (in the base directory) `pip install .` to install the package into a local environment, then use it from any other Python module (located anywhere on your machine) with `import osd`.

Later, when you know which versions of the dependencies you require, you can add that information to this file.